### PR TITLE
cert_renewal: Used penultimate TRC if still in grace period of latest TRC

### DIFF
--- a/pkg/certutils/paths.go
+++ b/pkg/certutils/paths.go
@@ -5,8 +5,6 @@ import (
 	"path/filepath"
 	"sort"
 	"strings"
-
-	"github.com/netsys-lab/scion-orchestrator/pkg/fileops"
 )
 
 func GetASCertificateFilename(configDir, isdAs string) (string, error) {
@@ -23,19 +21,36 @@ func GetASPrivateKeyFilename(configDir string) string {
 	return filepath.Join(configDir, "crypto", "as", "cp-as.key")
 }
 
-func GetLatestTRCForISD(configDir, isd string) (string, error) {
-	trcPath := filepath.Join(configDir, "certs")
-	trcFiles, err := fileops.ListFilesByPrefixAndSuffix(trcPath, "ISD"+isd+"-", ".trc")
-	sort.Strings(trcFiles)
-
+func GetTwoLatestTRCsForISD(listFiles func(string, string, string) ([]string, error), configDir, isd string) (string, string, error) {
+	var laterstTRC string
+	var penultimateTRC string
+	trcDir := filepath.Join(configDir, "certs")
+	trcFiles, err := listFiles(trcDir, "ISD"+isd, ".trc")
 	if err != nil {
-		return "", fmt.Errorf("failed to list TRC files: %s", err.Error())
+		return "", "", err
 	}
-
 	if len(trcFiles) == 0 {
-		return "", fmt.Errorf("no TRC files found for ISD %s", isd)
+		return "", "", fmt.Errorf("No TRC files found in %s", trcDir)
 	}
+	sort.Slice(trcFiles, func(i, j int) bool {
+		filenameI := filepath.Base(trcFiles[i])
+		filenameJ := filepath.Base(trcFiles[j])
 
-	trcFile := trcFiles[len(trcFiles)-1]
-	return trcFile, nil
+		var bI, sI, bJ, sJ, isdI, isdJ int
+		fmt.Sscanf(filenameI, "ISD%d-B%d-S%d.trc", &isdI, &bI, &sI)
+		fmt.Sscanf(filenameJ, "ISD%d-B%d-S%d.trc", &isdJ, &bJ, &sJ)
+
+		if bI != bJ {
+			return bI < bJ
+		}
+		return sI < sJ
+	})
+
+	laterstTRC = trcFiles[len(trcFiles)-1] // Get the latest TRC version
+	if len(trcFiles) > 1 {
+		// XXX: This parameter is input to the scion-pki command, which internally
+		// verifies that the penultimate TRC is in the grace period of the latest TRC.
+		penultimateTRC = trcFiles[len(trcFiles)-2] // Get the penultimate TRC version
+	}
+	return laterstTRC, penultimateTRC, nil
 }

--- a/pkg/certutils/scion.go
+++ b/pkg/certutils/scion.go
@@ -9,6 +9,7 @@ import (
 // TODO: Windows Support
 func VerifySCIONCertificateChain(certFile string, trcFile string) error {
 	cmd := exec.Command("scion-pki", "certificate", "verify", "--trc", trcFile, certFile)
+	log.Println("[CertUtils] Verifying certificate chain, ", cmd.String())
 	_, err := cmd.CombinedOutput()
 	if err != nil {
 		log.Println("[CertUtils] Could not verify the certificate chain: " + err.Error())

--- a/pkg/scionca/cert_renewal_test.go
+++ b/pkg/scionca/cert_renewal_test.go
@@ -69,28 +69,32 @@ func TestLoadCertificateFiles(t *testing.T) {
 	trcPath10 := createTRCFile(t, trcDir, isd, 1, 10)
 
 	tests := []struct {
-		name          string
-		trcFiles      []string
-		expectedTRC   string
-		expectSuccess bool
+		name                   string
+		trcFiles               []string
+		expectedLatestTRC      string
+		expectedPenultimateTRC string
+		expectSuccess          bool
 	}{
 		{
-			name:          "Only trcPath1",
-			trcFiles:      []string{trcPath1},
-			expectedTRC:   trcPath1,
-			expectSuccess: true,
+			name:                   "Only trcPath1",
+			trcFiles:               []string{trcPath1},
+			expectedLatestTRC:      trcPath1,
+			expectedPenultimateTRC: "",
+			expectSuccess:          true,
 		},
 		{
-			name:          "Both trcPath9 and trcPath10",
-			trcFiles:      []string{trcPath10, trcPath9},
-			expectedTRC:   trcPath10,
-			expectSuccess: true,
+			name:                   "Both trcPath9 and trcPath10",
+			trcFiles:               []string{trcPath10, trcPath9},
+			expectedLatestTRC:      trcPath10,
+			expectedPenultimateTRC: trcPath9,
+			expectSuccess:          true,
 		},
 		{
-			name:          "No TRC files",
-			trcFiles:      []string{},
-			expectedTRC:   "",
-			expectSuccess: false,
+			name:                   "No TRC files",
+			trcFiles:               []string{},
+			expectedLatestTRC:      "",
+			expectedPenultimateTRC: "",
+			expectSuccess:          false,
 		},
 	}
 
@@ -126,8 +130,11 @@ func TestLoadCertificateFiles(t *testing.T) {
 				if cr.CertPath != certPath {
 					t.Errorf("Expected CertPath to be %s, got %s", certPath, cr.CertPath)
 				}
-				if cr.TRC != tt.expectedTRC {
-					t.Errorf("Expected TRC to be %s, got %s", tt.expectedTRC, cr.TRC)
+				if cr.LatestTRC != tt.expectedLatestTRC {
+					t.Errorf("Expected LatestTRC to be %s, got %s", tt.expectedLatestTRC, cr.LatestTRC)
+				}
+				if cr.PenultimateTRC != tt.expectedPenultimateTRC {
+					t.Errorf("Expected PenultimateTRC to be %s, got %s", tt.expectedPenultimateTRC, cr.PenultimateTRC)
 				}
 			} else if err == nil {
 				t.Error("Expected error, got nil")


### PR DESCRIPTION
This PR introduces the feature of falling back to the penultimate TRC if it is still within the Grace Period of the latest TRC. It may happen that the CA renews the certificate signing with any of those TRCs. Thus, we should check both.

 Note that the `inGracePeriod` check is now implicit in the `scion-pki` tool, we are not adding the check again in the orchestrator. What we do is using the penultimate TRC if we have an error on renewing/verifying with the latest TRC. If it is still in the grace period `scion-pki renew` will use this TRC, otherwise, it will return an error.